### PR TITLE
Support ControllerRegistration in same yaml file as ControllerDeployment

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 
 	gemv1alpha1 "github.com/gardener/gem/pkg/gem/api/v1alpha1"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	gemioutil "github.com/gardener/gem/pkg/util/io"
 
@@ -115,7 +114,7 @@ func WriteLocksIntoFileOrWriteCloser(locks *gemapi.Locks, filename string, wc io
 	return gem.WriteLocksInto(locks, wc)
 }
 
-func WriteControllerRegistrationsInto(registrations []*gardencorev1beta1.ControllerRegistration, w io.Writer) error {
+func WriteControllerRegistrationsInto(registrations []runtime.Object, w io.Writer) error {
 	for i, registration := range registrations {
 		if i != 0 {
 			if _, err := fmt.Fprint(w, "---"); err != nil {
@@ -134,7 +133,7 @@ func WriteControllerRegistrationsInto(registrations []*gardencorev1beta1.Control
 	return nil
 }
 
-func WriteControllerRegistrationsIntoFileOrWriteCloser(registrations []*gardencorev1beta1.ControllerRegistration, filename string, wc io.WriteCloser) error {
+func WriteControllerRegistrationsIntoFileOrWriteCloser(registrations []runtime.Object, filename string, wc io.WriteCloser) error {
 	wc, err := FileOrWriteCloser(filename, wc)
 	if err != nil {
 		return err

--- a/pkg/gem/cache.go
+++ b/pkg/gem/cache.go
@@ -14,6 +14,8 @@
 
 package gem
 
+import "io"
+
 type fileKey struct {
 	hash string
 	path string
@@ -97,7 +99,7 @@ func (c *cachingRepository) Latest() (string, error) {
 	return latest, nil
 }
 
-func (c *cachingRepository) File(hash, path string) ([]byte, error) {
+func (c *cachingRepository) File(hash, path string) (io.Reader, error) {
 	return c.repository.File(hash, path)
 }
 

--- a/pkg/gem/git.go
+++ b/pkg/gem/git.go
@@ -15,6 +15,7 @@
 package gem
 
 import (
+	"io"
 	"net/url"
 
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
@@ -121,18 +122,18 @@ func (g *gitRepository) fileObject(hash, path string) (*object.File, error) {
 	return commit.File(path)
 }
 
-func (g *gitRepository) File(hash, path string) ([]byte, error) {
+func (g *gitRepository) File(hash, path string) (io.Reader, error) {
 	file, err := g.fileObject(hash, path)
 	if err != nil {
 		return nil, err
 	}
 
-	contents, err := file.Contents()
+	r, err := file.Reader()
 	if err != nil {
 		return nil, err
 	}
 
-	return []byte(contents), nil
+	return r, nil
 }
 
 func (g *gitRepository) HasFile(hash, path string) (bool, error) {

--- a/pkg/gem/types.go
+++ b/pkg/gem/types.go
@@ -16,8 +16,9 @@ package gem
 
 import (
 	"github.com/Masterminds/semver"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gemapi "github.com/gardener/gem/pkg/gem/api"
+	"io"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type RepositoryRegistry interface {
@@ -35,7 +36,7 @@ type Repository interface {
 	Branch(name string) (string, error)
 	Versions() ([]RepositoryVersion, error)
 	Latest() (string, error)
-	File(hash, path string) ([]byte, error)
+	File(hash, path string) (io.Reader, error)
 	HasFile(hash, path string) (bool, error)
 }
 
@@ -62,12 +63,12 @@ type RepositoryInterface interface {
 	Verify(submodule string, requirement *gemapi.Requirement, lock *gemapi.Lock) error
 	Solve(submodule string, requirement *gemapi.Requirement) (*gemapi.Lock, error)
 	Ensure(submodule string, requirement *gemapi.Requirement, lock *gemapi.Lock, update bool) (*gemapi.Lock, error)
-	Fetch(submodule string, requirement *gemapi.Requirement, lock *gemapi.Lock) (*gardencorev1beta1.ControllerRegistration, error)
+	Fetch(submodule string, requirement *gemapi.Requirement, lock *gemapi.Lock) ([]runtime.Object, error)
 }
 
 type Interface interface {
 	Repository(repositoryName string) (RepositoryInterface, error)
 	Solve(requirements *gemapi.Requirements) (*gemapi.Locks, error)
-	Fetch(requirements *gemapi.Requirements, locks *gemapi.Locks) ([]*gardencorev1beta1.ControllerRegistration, error)
+	Fetch(requirements *gemapi.Requirements, locks *gemapi.Locks) ([]runtime.Object, error)
 	Ensure(requirements *gemapi.Requirements, locks *gemapi.Locks, updatePolicy UpdatePolicy) (*gemapi.Locks, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the introduction of ControllerDeployments in https://github.com/gardener/gardener/pull/3995, extensions contain two Objects in their `example/controller-registration.yaml`, which breaks `gem`.

**Which issue(s) this PR fixes**:
Fixes #4

**Special notes for your reviewer**:
No idea if this is the right way to do it, but it works. We lose some type safety on the way, technically `gem` doesn't care anymore now _what_ is inside the `controller-registration.yaml` file it finds. We could add this within the `Fetch` method, I guess, if we wanted. The whole `Fetch` method isn't pretty, there are no tests, but "it works"(tm)

