### PR TITLE
Fix for referencing remote branches

### DIFF
--- a/pkg/gem/git.go
+++ b/pkg/gem/git.go
@@ -15,10 +15,9 @@
 package gem
 
 import (
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"io"
 	"net/url"
-
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
 
 	"github.com/Masterminds/semver"
 	"gopkg.in/src-d/go-git.v4"

--- a/pkg/gem/git.go
+++ b/pkg/gem/git.go
@@ -68,7 +68,7 @@ func (g *gitRepository) Revision(name string) (string, error) {
 }
 
 func (g *gitRepository) Branch(name string) (string, error) {
-	ref, err := g.repo.Reference(plumbing.NewBranchReferenceName(name), true)
+	ref, err := g.repo.Reference(plumbing.NewRemoteReferenceName("origin", name), true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Referencing a git remote branch via the `branch` directive wasn't working – the code didn't find the branch specified. The used method `NewBranchReferenceName` is looking at `refs/heads/<branch-name>` for the specified branch, while now, `NewRemoteReferenceName` looks at `/refs/remotes/origin/<branch-name>`
