### PR TITLE
Enh/error handling

### DIFF
--- a/gem.go
+++ b/gem.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	gemcmd "github.com/gardener/gem/pkg/cmd"
@@ -26,7 +25,6 @@ import (
 
 func main() {
 	if err := cmd.Command(gem.Default, gemcmd.OsStreams).Execute(); err != nil {
-		fmt.Printf("%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cmd/gem/gem.go
+++ b/pkg/cmd/gem/gem.go
@@ -38,6 +38,7 @@ func Command(g gem.Interface, streams *gemcmd.Streams) *cobra.Command {
 			gem.DefaultLogger.SetLevel(logLevel)
 			return nil
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().StringVarP(&level, gemcmd.DefaultLogLevelFlag, gemcmd.DefaultLogLevelFlagP, gemcmd.DefaultLogLevel, gemcmd.DefaultLogLevelUsage)

--- a/pkg/gem/gem.go
+++ b/pkg/gem/gem.go
@@ -210,13 +210,13 @@ func (g *gem) Solve(requirements *gemapi.Requirements) (*gemapi.Locks, error) {
 		log.Debug("Retrieving repository")
 		repositoryInterface, err := g.Repository(moduleKey.Repository)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not retrieve repository %q: %w", &moduleKey, err)
 		}
 
 		log.Debug("Solving requirement")
 		lock, err := repositoryInterface.Solve(moduleKey.Submodule, requirement)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not solve requirement %q for extension %q: %w", &requirement.Target, &moduleKey, err)
 		}
 
 		log = withLockLogger(log, lock)
@@ -237,19 +237,19 @@ func (g *gem) Fetch(requirements *gemapi.Requirements, locks *gemapi.Locks) ([]r
 		log.Debug("Retrieving repository")
 		repositoryInterface, err := g.Repository(moduleKey.Repository)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not retrieve repository %q: %w", &moduleKey, err)
 		}
 
-		log.Debug("Checking whether lock for is present")
+		log.Debug("Checking whether lock is present")
 		lock, ok := locks.Locks[moduleKey]
 		if !ok {
-			return nil, fmt.Errorf("no lock recorded for %s", moduleKey)
+			return nil, fmt.Errorf("no lock recorded for %q", &moduleKey)
 		}
 
 		log.Debug("Fetching controller installation")
 		registration, err := repositoryInterface.Fetch(moduleKey.Submodule, requirement, lock)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not fetch registration for %s", &moduleKey)
+			return nil, errors.Wrapf(err, "could not fetch registration for %q", &moduleKey)
 		}
 
 		log.Info("Successfully fetched")
@@ -269,7 +269,7 @@ func (g *gem) Ensure(requirements *gemapi.Requirements, locks *gemapi.Locks, upd
 		log.Debug("Retrieving repository")
 		repositoryInterface, err := g.Repository(moduleKey.Repository)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not retrieve repository %q: %w", &moduleKey, err)
 		}
 
 		log.Debug("Checking for old lock")
@@ -285,7 +285,7 @@ func (g *gem) Ensure(requirements *gemapi.Requirements, locks *gemapi.Locks, upd
 		log.Debug("Ensuring requirement with optional lock")
 		lock, err := repositoryInterface.Ensure(moduleKey.Submodule, requirement, oldLock, update)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not ensure requirement %q for repository %q: %w", requirement, &moduleKey, err)
 		}
 
 		log = withLockLogger(log, lock)

--- a/pkg/gem/gem.go
+++ b/pkg/gem/gem.go
@@ -185,12 +185,6 @@ func (g *gem) Repository(repositoryName string) (RepositoryInterface, error) {
 	return &repositoryInterface{targetSolver: g.targetSolverFactory.New(repo), repository: repo}, nil
 }
 
-const (
-	moduleKeyField   = "moduleKey"
-	requirementField = "requirement"
-	lockField        = "lock"
-)
-
 func withUpdateLogger(log logrus.FieldLogger, update bool) logrus.FieldLogger {
 	return log.WithField("update", update)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds the parameter `SilenceUsage: true` to the command creation, such that we don't display the usage help on each and every error
* Removes duplicate error output

**Which issue(s) this PR fixes**:
Fixes #6 
Fixes #7 

